### PR TITLE
clicking on weak supervision results adds them to manual label set

### DIFF
--- a/src/app/labeling/components/labeling.component.html
+++ b/src/app/labeling/components/labeling.component.html
@@ -277,7 +277,8 @@
                                                                             <ng-template
                                                                                 [ngIf]="rla.sourceType == LabelSourceType.WEAK_SUPERVISION"
                                                                                 [ngIfElse]="displayCallback">
-                                                                                <div class="text-sm font-medium mr-3 px-2 py-0.5 rounded-md border border-dotted mr-2 pr-0.5 cursor-default"
+                                                                                <div class="cursor-pointer text-sm font-medium mr-3 px-2 py-0.5 rounded-md border border-dotted mr-2 pr-0.5 cursor-default"
+                                                                                    (click)="addLabelToTask(task.id, rla.labelingTaskLabel.id)"
                                                                                     [ngClass]="[getBackground(rla.labelingTaskLabel.color), getText(rla.labelingTaskLabel.color), getBorder(rla.labelingTaskLabel.color)]">
                                                                                     <svg xmlns="http://www.w3.org/2000/svg"
                                                                                         class="inline-block icon icon-tabler icon-tabler-assembly"
@@ -807,11 +808,13 @@
     <div *ngIf="overlayData && overlayData.isFirst" class="w-0 h-14 relative">
         <div class="absolute bottom-3">
             <div hover-group-class="hover_child_hover" [hover-group]="overlayData.group"
-                class="absolute w-0 hover_child " style="bottom: 0;left:3px">
+                class="absolute w-0 hover_child " style="bottom: 0;left:3px"
+                (click)="addLabelToMarkedTextFromSuggestion(overlayData)">
+
                 <div class="relative" style="z-index:2">
                     <label
                         [ngClass]="[getBackground(overlayData.labelColor), getText(overlayData.labelColor), getBorder(overlayData.labelColor), getHover(overlayData.labelColor)]"
-                        class="rounded-lg font-medium px-1 normal-case whitespace-nowrap">{{overlayData.labelDisplay}}</label>
+                        class="cursor-pointer rounded-lg font-medium px-1 normal-case whitespace-nowrap">{{overlayData.labelDisplay}}</label>
                 </div>
             </div>
         </div>

--- a/src/app/labeling/components/labeling.component.ts
+++ b/src/app/labeling/components/labeling.component.ts
@@ -775,9 +775,13 @@ export class LabelingComponent implements OnInit, OnDestroy {
           let overlayData = {
             token: token,
             group: key,
+            tokenStartIdx: md.tokenStartIdx,
+            tokenEndIdx: md.tokenEndIdx,
+            value: md.value,
             isFirst: i == md.tokenStartIdx,
             isLast: i == md.tokenEndIdx,
             labelName: md.labelingTaskLabel.name,
+            labelingTaskId: md.labelingTaskLabel.labelingTask.id,
             labelId: md.labelingTaskLabel.id,
             labelDisplay: this.getLabelForDisplay(
               md.labelingTaskLabel.name,
@@ -1389,7 +1393,31 @@ export class LabelingComponent implements OnInit, OnDestroy {
     }
   }
 
+  addLabelToMarkedTextFromSuggestion(overlayData) {
+    const dataEntry = {
+      startIdx: overlayData.tokenStartIdx,
+      endIdx: overlayData.tokenEndIdx,
+      value: overlayData.value,
+    };
+
+    this.somethingLoading = true;
+    this.recordApolloService
+      .addExtractionLabelToRecord(
+        this.project.id,
+        this.fullRecordData.id,
+        overlayData.labelingTaskId,
+        dataEntry.startIdx,
+        dataEntry.endIdx,
+        dataEntry.value,
+        overlayData.labelId,
+        this.displayUserId == this.GOLD_USER_ID ? true : null
+      )
+      .pipe(first())
+      .subscribe();
+  }
+
   addLabelToMarkedText(taskId: string, labelId: string) {
+
     if (!this.selectionJSON) return;
     if (this.selectionJSON.error) return;
 
@@ -1420,7 +1448,7 @@ export class LabelingComponent implements OnInit, OnDestroy {
       )
       .pipe(first())
       .subscribe();
-      
+
   }
 
   addLabelToTask(labelingTaskId: string, labelId: string) {


### PR DESCRIPTION
Clicking on a weakly supervised label now adds them to the manual labeling set. Addresses code-kern-ai/refinery#51.

Next step could possibly be to tab-navigate through weak supervision results, and accepting them via enter.