### PR TITLE
Enable Attribute calculation for different data types

### DIFF
--- a/src/app/base/components/dropdown/dropdown-helper.ts
+++ b/src/app/base/components/dropdown/dropdown-helper.ts
@@ -31,6 +31,7 @@ import { FormArray } from "@angular/forms";
  * @addScrollXDropdownOptions {boolean, optional} - checks if the dropdown options should have a scrollX for longer texts with limitted space
  * @maxHeight {string, optional} - sets the max height of the dropdown options
  * @maxWidth {string, optional} - sets the max width of the dropdown options
+ * @hasFullWidth {string, optional} - sets the width of the dropdown options and the button to 100%
 */
 export type DropdownOptions = {
     optionArray: string[] | FormArray[] | any[];
@@ -62,5 +63,6 @@ export type DropdownOptions = {
     addScrollXDropdownOptions: boolean;
     maxHeight?: string;
     maxWidth?: string;
+    hasFullWidth?: boolean;
 };
 

--- a/src/app/base/components/dropdown/dropdown.component.html
+++ b/src/app/base/components/dropdown/dropdown.component.html
@@ -1,4 +1,5 @@
-<div class="relative" [ngClass]="dropdownOptions.buttonVersion == 'default' ? ' w-max' : '' ">
+<div class="relative"
+    [ngClass]="[dropdownOptions.buttonVersion == 'default' && !dropdownOptions.hasFullWidth ? ' w-max' : '', dropdownOptions.hasFullWidth ? 'w-full' : '']">
     <div [ngClass]="dropdownOptions.buttonTooltip? tooltipClassList: ''"
         [attr.data-tip]="dropdownOptions.buttonTooltip">
 

--- a/src/app/base/components/dropdown/dropdown.component.ts
+++ b/src/app/base/components/dropdown/dropdown.component.ts
@@ -64,6 +64,7 @@ export class DropdownComponent implements OnChanges {
     this.dropdownClassList = this.dropdownOptions.hasCheckboxes ? ' w-80 ' : '';
     this.dropdownClassList += this.dropdownOptions.buttonVersion != 'default' ? 'right-0 width-icon-menues' : '';
     this.buttonClassList += this.dropdownOptions.isButtonSampleProjects ? 'py-2' : 'border-gray-300 py-1.5';
+    this.buttonClassList += this.dropdownOptions.hasFullWidth ? ' w-full ' : '';
     this.buttonClassList += this.dropdownClassList;
     this.tooltipClassList = this.getTooltipClasses();
   }

--- a/src/app/base/services/project/project-apollo.service.ts
+++ b/src/app/base/services/project/project-apollo.service.ts
@@ -1057,11 +1057,13 @@ export class ProjectApolloService {
 
   }
 
-  createUserAttribute(projectId: string): Observable<any> {
+  createUserAttribute(projectId: string, name: string, dataType: string): Observable<any> {
     return this.apollo.mutate({
       mutation: mutations.CREATE_USER_ATTRIBUTE,
       variables: {
-        projectId: projectId
+        projectId: projectId,
+        name: name,
+        dataType: dataType
       },
     });
   }

--- a/src/app/base/services/project/project-mutations.ts
+++ b/src/app/base/services/project/project-mutations.ts
@@ -193,8 +193,8 @@ export const mutations = {
   }
   `,
   CREATE_USER_ATTRIBUTE: gql`
-  mutation($projectId: ID!){
-    createUserAttribute(projectId: $projectId) {
+  mutation($projectId: ID!, $name: String!, $dataType: String!){
+    createUserAttribute(projectId: $projectId, name: $name, dataType: $dataType) {
       ok
       attributeId
     } 

--- a/src/app/projects/components/create-new-attribute/create-new-attribute.component.html
+++ b/src/app/projects/components/create-new-attribute/create-new-attribute.component.html
@@ -78,6 +78,17 @@
 
 
             <div class="flex flex-row items-center mt-2">
+                <div class="text-sm leading-5 font-medium text-gray-700 inline-block mr-2">Data types</div>
+                <kern-dropdown [dropdownOptions]="{
+                    optionArray: dataTypesArray,
+                    buttonCaption: attributeDataType,
+                    valuePropertyPath: 'value'
+                }" (optionClicked)="updateDataType($event)">
+                </kern-dropdown>
+            </div>
+
+
+            <div class="flex flex-row items-center mt-2">
                 <div class="text-sm leading-5 font-medium text-gray-700 inline-block mr-2">Editor</div>
                 <div class="ml-auto">
                     <a href="https://github.com/code-kern-ai/refinery-ac-exec-env/blob/release/requirements.txt"

--- a/src/app/projects/components/create-new-attribute/create-new-attribute.component.html
+++ b/src/app/projects/components/create-new-attribute/create-new-attribute.component.html
@@ -62,9 +62,10 @@
                     <div class="text-sm leading-5 font-medium text-gray-700 inline-block mr-2">Attributes</div>
                     <ng-template [ngIf]="attributesUsableUploaded.length > 0" [ngIfElse]="noAttributes">
                         <span *ngFor="let attribute of attributesUsableUploaded"
-                            (click)="copyToClipboard(attribute.name)" data-tip="Click to copy" class="tooltip">
-                            <div
-                                class="cursor-pointer border items-center px-2 py-0.5 rounded text-xs font-medium text-center m-2 bg-gray-100 text-gray-700 border-gray-400 hover:bg-gray-200">
+                            (click)="copyToClipboard(attribute.name)"
+                            [attr.data-tip]="attribute.dataTypeName + ' - Click to copy' " class="tooltip">
+                            <div [ngClass]="'bg-'+attribute.color+'-100 text-'+attribute.color+'-700 border border-'+attribute.color+'-400 hover:bg-'+attribute.color+'-200'"
+                                class="cursor-pointer border items-center px-2 py-0.5 rounded text-xs font-medium text-center m-2">
                                 {{attribute.name}}
                             </div>
                         </span>
@@ -81,13 +82,13 @@
                 <div class="text-sm leading-5 font-medium text-gray-700 inline-block mr-2">Data types</div>
                 <div class="tooltip tooltip-right"
                     [attr.data-tip]="currentAttribute.state == 'USABLE' || currentAttribute.state == 'RUNNING' ? 'Cannot edit data type' : 'Edit your data type'">
-                        <kern-dropdown [dropdownOptions]="{
+                    <kern-dropdown [dropdownOptions]="{
                             optionArray: dataTypesArray,
                             buttonCaption: attributeDataType,
                             valuePropertyPath: 'value',
                             isDisabled: currentAttribute.state == 'USABLE' || currentAttribute.state == 'RUNNING'
                         }" (optionClicked)="updateDataType($event)">
-                        </kern-dropdown>
+                    </kern-dropdown>
                 </div>
             </div>
 

--- a/src/app/projects/components/create-new-attribute/create-new-attribute.component.html
+++ b/src/app/projects/components/create-new-attribute/create-new-attribute.component.html
@@ -79,12 +79,16 @@
 
             <div class="flex flex-row items-center mt-2">
                 <div class="text-sm leading-5 font-medium text-gray-700 inline-block mr-2">Data types</div>
-                <kern-dropdown [dropdownOptions]="{
-                    optionArray: dataTypesArray,
-                    buttonCaption: attributeDataType,
-                    valuePropertyPath: 'value'
-                }" (optionClicked)="updateDataType($event)">
-                </kern-dropdown>
+                <div class="tooltip tooltip-right"
+                    [attr.data-tip]="currentAttribute.state == 'USABLE' || currentAttribute.state == 'RUNNING' ? 'Cannot edit data type' : 'Edit your data type'">
+                        <kern-dropdown [dropdownOptions]="{
+                            optionArray: dataTypesArray,
+                            buttonCaption: attributeDataType,
+                            valuePropertyPath: 'value',
+                            isDisabled: currentAttribute.state == 'USABLE' || currentAttribute.state == 'RUNNING'
+                        }" (optionClicked)="updateDataType($event)">
+                        </kern-dropdown>
+                </div>
             </div>
 
 

--- a/src/app/projects/components/create-new-attribute/create-new-attribute.component.ts
+++ b/src/app/projects/components/create-new-attribute/create-new-attribute.component.ts
@@ -15,7 +15,7 @@ import { AttributeCalculationExamples, AttributeCodeLookup } from './new-attribu
 import { RecordApolloService } from 'src/app/base/services/record/record-apollo.service';
 import { CommentDataManager, CommentType } from 'src/app/base/components/comment/comment-helper';
 import { dataTypes } from 'src/app/util/data-types';
-import { toPythonFunctionName } from 'src/app/util/helper-functions';
+import { getColorForDataType, toPythonFunctionName } from 'src/app/util/helper-functions';
 
 @Component({
   selector: 'kern-create-new-attribute',
@@ -373,6 +373,10 @@ export class CreateNewAttributeComponent implements OnInit, OnDestroy {
       attributes.sort((a, b) => a.relativePosition - b.relativePosition);
       this.attributes = attributes;
       this.attributesUsableUploaded = this.attributes.filter((attribute) => attribute.state == 'UPLOADED' || attribute.state == 'USABLE' || attribute.state == 'AUTOMATICALLY_CREATED');
+      this.attributesUsableUploaded.forEach(attribute => {
+        attribute.color = getColorForDataType(attribute.dataType);
+        attribute.dataTypeName = this.dataTypesArray.find((type) => type.value === attribute.dataType).name;
+      });
       this.checkIfAtLeastRunning = this.checkIfSomethingRunning();
     }));
     return attributes$.pipe(first());

--- a/src/app/projects/components/create-new-attribute/create-new-attribute.component.ts
+++ b/src/app/projects/components/create-new-attribute/create-new-attribute.component.ts
@@ -14,6 +14,7 @@ import { NotificationService } from 'src/app/base/services/notification.service'
 import { AttributeCalculationExamples, AttributeCodeLookup } from './new-attribute-code-lookup';
 import { RecordApolloService } from 'src/app/base/services/record/record-apollo.service';
 import { CommentDataManager, CommentType } from 'src/app/base/components/comment/comment-helper';
+import { dataTypes } from 'src/app/util/data-types';
 
 @Component({
   selector: 'kern-create-new-attribute',
@@ -56,6 +57,9 @@ export class CreateNewAttributeComponent implements OnInit, OnDestroy {
   isDeleting: boolean = false;
   duplicateNameExists: boolean = false;
   runOn10HasError: boolean = false;
+
+  dataTypesArray = dataTypes;
+  attributeDataType: string;
 
   constructor(
     private activatedRoute: ActivatedRoute,
@@ -154,6 +158,7 @@ export class CreateNewAttributeComponent implements OnInit, OnDestroy {
     this.subscriptions$.push(this.attribute$.subscribe((attribute) => {
       this.currentAttribute = attribute;
       this.attributeName = this.currentAttribute?.name;
+      this.attributeDataType = this.dataTypesArray.find((type) => type.value === this.currentAttribute?.dataType).name;
       this.code = this.currentAttribute?.sourceCode;
       if (this.currentAttribute?.sourceCode == null) {
         this.code = AttributeCodeLookup.getAttributeCalculationTemplate(AttributeCalculationExamples.AC_EMPTY_TEMPLATE).code;
@@ -391,5 +396,10 @@ export class CreateNewAttributeComponent implements OnInit, OnDestroy {
     this.projectApolloService.getProjectTokenization(projectId).pipe(first()).subscribe((v) => {
       this.tokenizationProgress = v?.progress;
     })
+  }
+
+  updateDataType(dataType: string) {
+    this.currentAttribute.dataType = dataType;
+    this.saveAttribute(this.project.id);
   }
 }

--- a/src/app/projects/components/create-new-attribute/create-new-attribute.component.ts
+++ b/src/app/projects/components/create-new-attribute/create-new-attribute.component.ts
@@ -162,7 +162,7 @@ export class CreateNewAttributeComponent implements OnInit, OnDestroy {
       this.attributeDataType = this.dataTypesArray.find((type) => type.value === this.currentAttribute?.dataType).name;
       this.code = this.currentAttribute?.sourceCode;
       if (this.currentAttribute?.sourceCode == null) {
-        this.code = AttributeCodeLookup.getAttributeCalculationTemplate(AttributeCalculationExamples.AC_EMPTY_TEMPLATE).code;
+        this.code = AttributeCodeLookup.getAttributeCalculationTemplate(AttributeCalculationExamples.AC_EMPTY_TEMPLATE, this.currentAttribute.dataType).code;
       } else {
         this.code = this.code.replace(
           'def ac(record):',
@@ -401,6 +401,11 @@ export class CreateNewAttributeComponent implements OnInit, OnDestroy {
 
   updateDataType(dataType: string) {
     this.currentAttribute.dataType = dataType;
+    this.code = AttributeCodeLookup.getAttributeCalculationTemplate(AttributeCalculationExamples.AC_EMPTY_TEMPLATE, this.currentAttribute.dataType).code;
+    this.code = this.code.replace(
+      'def ac(record):',
+      'def ' + this.currentAttribute.name + '(record):'
+    );
     this.saveAttribute(this.project.id);
   }
 }

--- a/src/app/projects/components/create-new-attribute/create-new-attribute.component.ts
+++ b/src/app/projects/components/create-new-attribute/create-new-attribute.component.ts
@@ -15,6 +15,7 @@ import { AttributeCalculationExamples, AttributeCodeLookup } from './new-attribu
 import { RecordApolloService } from 'src/app/base/services/record/record-apollo.service';
 import { CommentDataManager, CommentType } from 'src/app/base/components/comment/comment-helper';
 import { dataTypes } from 'src/app/util/data-types';
+import { toPythonFunctionName } from 'src/app/util/helper-functions';
 
 @Component({
   selector: 'kern-create-new-attribute',
@@ -211,10 +212,6 @@ export class CreateNewAttributeComponent implements OnInit, OnDestroy {
     }
   }
 
-  toPythonFunctionName(str: string) {
-    return str.replace(/\s+/g, '_').replace(/[^\w]/gi, '').trim();
-  }
-
   saveAttribute(projectId: string) {
     if (this.updatedThroughWebsocket) return;
     const getCodeToSave = this.getPythonFunctionToSave(this.code);
@@ -225,7 +222,7 @@ export class CreateNewAttributeComponent implements OnInit, OnDestroy {
   }
 
   changeAttributeName(event) {
-    this.attributeName = this.toPythonFunctionName(event.target.value);
+    this.attributeName = toPythonFunctionName(event.target.value);
     if (this.attributeName != event.target.value) {
       event.target.value = this.attributeName;
     }

--- a/src/app/projects/components/create-new-attribute/create-new-attribute.component.ts
+++ b/src/app/projects/components/create-new-attribute/create-new-attribute.component.ts
@@ -401,11 +401,6 @@ export class CreateNewAttributeComponent implements OnInit, OnDestroy {
 
   updateDataType(dataType: string) {
     this.currentAttribute.dataType = dataType;
-    this.code = AttributeCodeLookup.getAttributeCalculationTemplate(AttributeCalculationExamples.AC_EMPTY_TEMPLATE, this.currentAttribute.dataType).code;
-    this.code = this.code.replace(
-      'def ac(record):',
-      'def ' + this.currentAttribute.name + '(record):'
-    );
     this.saveAttribute(this.project.id);
   }
 }

--- a/src/app/projects/components/create-new-attribute/new-attribute-code-lookup.ts
+++ b/src/app/projects/components/create-new-attribute/new-attribute-code-lookup.ts
@@ -5,14 +5,50 @@ export enum AttributeCalculationExamples {
 }
 
 export class AttributeCodeLookup {
-    static getAttributeCalculationTemplate(l: AttributeCalculationExamples) {
+    static getAttributeCalculationTemplate(l: AttributeCalculationExamples, dataType: string) {
         switch (l) {
-            case AttributeCalculationExamples.AC_EMPTY_TEMPLATE:
-                return {
-                    code: `def ac(record):
-    # e.g.
-    return record["headline"].text.lower()
-                `}
+            case AttributeCalculationExamples.AC_EMPTY_TEMPLATE: {
+                switch (dataType) {
+                    case 'CATEGORY': return {
+                        code: `def ac(record):
+    # e.g. categorize the records conditional on the text length of a string attribute
+    text_length = len(record["str_attribute"].text)
+    if text_length < 35:
+        return "short"
+    elif text_length < 70:
+        return "normal"
+    else:
+        return "long"
+                    `}
+                    case 'TEXT': return {
+                        code: `def ac(record):
+    # e.g. transform the string attribute to lower case
+    return record["str_attribute"].text.lower()
+                    `}
+                    case 'BOOLEAN': return {
+                        code: `def ac(record):
+    # e.g. does the string attribute contain a digit
+    return any([token.is_digit for token in record["str_attribute"]])
+                    `}
+                    case 'INTEGER': return {
+                        code: `def ac(record):
+    # e.g. length of the longest word in string attribute
+    word_length = [len(word) for word in record["str_attribute"]]
+    return max(word_length)
+                    `}
+                    case 'FLOAT': return {
+                        code: `def ac(record):
+    # e.g. mean number of chars per word
+    words = record["str_attribute"].text.split()
+    num_words = len(words)
+    sum_word_lengths = sum([len(word) for word in words])
+    return sum_word_lengths / num_words
+                    `}
+                    default: return {
+                        code: ''
+                    }
+                }
+            }
         }
     }
 

--- a/src/app/projects/components/project-settings/project-settings.component.html
+++ b/src/app/projects/components/project-settings/project-settings.component.html
@@ -119,8 +119,8 @@
                     </div>
                     <input #newAttributeModal type="checkbox" id="new-attribute-modal" class="modal-toggle">
                     <div class="modal">
-                        <div class="modal-box modal_content text-black bg-white justify-center max-w-md"
-                            style="overflow-y:visible;overflow-x:unset">
+                        <div class="modal-box modal_content text-black bg-white justify-center"
+                            style="overflow-y:visible;overflow-x:unset;width: 448px;">
                             <div class="flex flex-grow justify-center text-lg leading-6 text-gray-900 font-medium">
                                 Add new attribute </div>
                             <div class="mb-2 flex flex-grow justify-center text-sm text-gray-500">
@@ -516,8 +516,8 @@
                     </div>
                     <input #modalInputEmbedding type="checkbox" id="my-modal-newEmbedding" class="modal-toggle">
                     <div class="modal">
-                        <div class="modal-box modal_content text-black bg-white justify-center max-w-md"
-                            style="overflow-y:visible;overflow-x:unset">
+                        <div class="modal-box modal_content text-black bg-white justify-center"
+                            style="overflow-y:visible;overflow-x:unset;width: 448px;">
                             <div class="flex flex-grow justify-center text-lg leading-6 text-gray-900 font-medium">
                                 Add an embedding </div>
                             <div class="mb-2 flex flex-grow justify-center text-sm text-gray-500">
@@ -881,7 +881,7 @@
             <input #modalInput type="checkbox" id="my-modal-newRecordTask" class="modal-toggle"
                 (change)="focusModalInputBox($event,'labelingTaskName')">
             <div class="modal">
-                <div class="modal-box text-black bg-white justify-center max-w-md" style="width:fit-content;">
+                <div class="modal-box text-black bg-white justify-center" style="width: 448px;">
                     <div class="flex flex-grow justify-center text-lg leading-6 text-gray-900 font-medium">
                         Add a labeling task </div>
                     <div class="mb-2 flex flex-grow justify-center text-sm text-gray-500">

--- a/src/app/projects/components/project-settings/project-settings.component.html
+++ b/src/app/projects/components/project-settings/project-settings.component.html
@@ -119,12 +119,12 @@
                     </div>
                     <input #newAttributeModal type="checkbox" id="new-attribute-modal" class="modal-toggle">
                     <div class="modal">
-                        <div class="modal-box modal_content text-black bg-white justify-center"
+                        <div class="modal-box modal_content text-black bg-white justify-center max-w-md"
                             style="overflow-y:visible;overflow-x:unset">
                             <div class="flex flex-grow justify-center text-lg leading-6 text-gray-900 font-medium">
                                 Add new attribute </div>
                             <div class="mb-2 flex flex-grow justify-center text-sm text-gray-500">
-                                Pick from the below solutions to build a vector representation</div>
+                                Choose a name for your attribute and pick a datatype you want to use</div>
 
                             <div class="grid grid-cols-2  gap-2 items-center"
                                 style="grid-template-columns: max-content auto;">
@@ -516,7 +516,7 @@
                     </div>
                     <input #modalInputEmbedding type="checkbox" id="my-modal-newEmbedding" class="modal-toggle">
                     <div class="modal">
-                        <div class="modal-box modal_content text-black bg-white justify-center"
+                        <div class="modal-box modal_content text-black bg-white justify-center max-w-md"
                             style="overflow-y:visible;overflow-x:unset">
                             <div class="flex flex-grow justify-center text-lg leading-6 text-gray-900 font-medium">
                                 Add an embedding </div>
@@ -881,7 +881,7 @@
             <input #modalInput type="checkbox" id="my-modal-newRecordTask" class="modal-toggle"
                 (change)="focusModalInputBox($event,'labelingTaskName')">
             <div class="modal">
-                <div class="modal-box text-black bg-white justify-center" style="width:fit-content;">
+                <div class="modal-box text-black bg-white justify-center max-w-md" style="width:fit-content;">
                     <div class="flex flex-grow justify-center text-lg leading-6 text-gray-900 font-medium">
                         Add a labeling task </div>
                     <div class="mb-2 flex flex-grow justify-center text-sm text-gray-500">

--- a/src/app/projects/components/project-settings/project-settings.component.html
+++ b/src/app/projects/components/project-settings/project-settings.component.html
@@ -117,7 +117,7 @@
                             Add new attibute
                         </label>
 
-                        <input type="checkbox" id="new-attribute-modal" class="modal-toggle">
+                        <input #newAttributeModal type="checkbox" id="new-attribute-modal" class="modal-toggle">
 
                         <div class="modal">
                             <div class="modal-box text-black bg-white justify-center" style="overflow: initial;">
@@ -133,8 +133,17 @@
                                             style="text-decoration-style: dotted;text-underline-offset: 2px;text-decoration-color: #22c55e">Attribute
                                             name</span></span>
                                     <input [(ngModel)]="attributeName" placeholder="Enter an attribute name..."
+                                        (input)="changeAttributeName($event)"
                                         class="input input-sm input-bordered placeholder-italic" />
 
+                                </div>
+
+                                <div class="text-red-700 text-xs mt-2" *ngIf="duplicateNameExists">
+                                    Attribute name exists
+                                </div>
+
+                                <div class="grid grid-cols-2 gap-2 items-center"
+                                    style="grid-template-columns: max-content auto;">
                                     <span data-tip="Select an attribute type"
                                         class="cursor-help tooltip tooltip-right card-title mb-0 label-text"><span
                                             class="underline"
@@ -146,10 +155,14 @@
                                     }" (optionClicked)="updateDataType($event)"></kern-dropdown>
                                 </div>
                                 <div class="modal-action text-center mt-4">
-                                    <label for="new-attribute-modal"
-                                        [ngClass]="attributeName == '' || attributeType == '' ? 'cursor-not-allowed opacity-50':'cursor-pointer opacity-100'"
-                                        class="bg-green-100 text-green-700 border border-green-400 text-white text-xs font-semibold mr-2 px-4 py-2 rounded-md cursor-pointer hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 inline-block"
-                                        (click)="createUserAttribute()">Create</label>
+                                    <div
+                                        [ngClass]="attributeName == '' || attributeType == '' || duplicateNameExists? 'cursor-not-allowed' : ''">
+                                        <label
+                                            [ngClass]="attributeName == '' || attributeType == '' || duplicateNameExists ? 'opacity-50 cursor-not-allowed pointer-events-none':'cursor-pointer opacity-100'"
+                                            class="bg-green-100 text-green-700 border border-green-400 text-white text-xs font-semibold mr-2 px-4 py-2 rounded-md cursor-pointer hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 inline-block"
+                                            (click)="createUserAttribute()">Create</label>
+                                    </div>
+
                                     <label for="new-attribute-modal"
                                         class="bg-white text-gray-700 text-xs font-semibold mr-4 px-4 py-2 rounded-md border border-gray-300 cursor-pointer hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 inline-block">Close</label>
                                 </div>

--- a/src/app/projects/components/project-settings/project-settings.component.html
+++ b/src/app/projects/components/project-settings/project-settings.component.html
@@ -116,59 +116,63 @@
                             </svg>
                             Add new attibute
                         </label>
+                    </div>
+                    <input #newAttributeModal type="checkbox" id="new-attribute-modal" class="modal-toggle">
+                    <div class="modal">
+                        <div class="modal-box modal_content text-black bg-white justify-center"
+                            style="overflow-y:visible;overflow-x:unset">
+                            <div class="flex flex-grow justify-center text-lg leading-6 text-gray-900 font-medium">
+                                Add new attribute </div>
+                            <div class="mb-2 flex flex-grow justify-center text-sm text-gray-500">
+                                Pick from the below solutions to build a vector representation</div>
 
-                        <input #newAttributeModal type="checkbox" id="new-attribute-modal" class="modal-toggle">
+                            <div class="grid grid-cols-2  gap-2 items-center"
+                                style="grid-template-columns: max-content auto;">
 
-                        <div class="modal">
-                            <div class="modal-box text-black bg-white justify-center" style="overflow: initial;">
-                                <h1 class="text-lg text-gray-900 mb-2 text-center mb-4">Add new attribute
-                                </h1>
+                                <span data-tip="Enter an attribute name"
+                                    class="cursor-help tooltip tooltip-right card-title mb-0 label-text font-normal"><span
+                                        class="underline"
+                                        style="text-decoration-style: dotted;text-underline-offset: 2px;text-decoration-color: #22c55e">Attribute
+                                        name</span></span>
+                                <input [(ngModel)]="attributeName" placeholder="Enter an attribute name..."
+                                    (input)="changeAttributeName($event)"
+                                    class="input input-sm input-bordered placeholder-italic" />
 
-                                <div class="grid grid-cols-2 gap-2 items-center"
-                                    style="grid-template-columns: max-content auto;">
+                                <ng-template [ngIf]="duplicateNameExists">
+                                    <span></span>
+                                    <span class="text-red-700 text-xs mt-2">
+                                        Attribute name exists
+                                    </span>
+                                </ng-template>
 
-                                    <span data-tip="Enter an attribute name"
-                                        class="cursor-help tooltip tooltip-right card-title mb-0 label-text"><span
-                                            class="underline"
-                                            style="text-decoration-style: dotted;text-underline-offset: 2px;text-decoration-color: #22c55e">Attribute
-                                            name</span></span>
-                                    <input [(ngModel)]="attributeName" placeholder="Enter an attribute name..."
-                                        (input)="changeAttributeName($event)"
-                                        class="input input-sm input-bordered placeholder-italic" />
-
-                                </div>
-
-                                <div class="text-red-700 text-xs mt-2" *ngIf="duplicateNameExists">
-                                    Attribute name exists
-                                </div>
-
-                                <div class="grid grid-cols-2 gap-2 items-center mt-3"
-                                    style="grid-template-columns: max-content auto;">
-                                    <span data-tip="Select an attribute type"
-                                        class="cursor-help tooltip tooltip-right card-title mb-0 label-text"><span
-                                            class="underline"
-                                            style="text-decoration-style: dotted;text-underline-offset: 2px;text-decoration-color: #22c55e">Attribute
-                                            type</span></span>
-                                    <kern-dropdown class="ml-1.5" [dropdownOptions]="{
+                                <span data-tip="Select an attribute type"
+                                    class="cursor-help tooltip tooltip-right card-title mb-0 label-text font-normal"><span
+                                        class="underline"
+                                        style="text-decoration-style: dotted;text-underline-offset: 2px;text-decoration-color: #22c55e">Attribute
+                                        type</span></span>
+                                <kern-dropdown [dropdownOptions]="{
                                         optionArray: dataTypesArray,
-                                        buttonCaption: attributeType
+                                        buttonCaption: attributeType,
+                                        hasFullWidth: true
                                     }" (optionClicked)="updateDataType($event)"></kern-dropdown>
-                                </div>
-                                <div class="modal-action text-center mt-4">
-                                    <div
-                                        [ngClass]="attributeName == '' || attributeType == '' || duplicateNameExists? 'cursor-not-allowed' : ''">
-                                        <label
-                                            [ngClass]="attributeName == '' || attributeType == '' || duplicateNameExists ? 'opacity-50 cursor-not-allowed pointer-events-none':'cursor-pointer opacity-100'"
-                                            class="bg-green-100 text-green-700 border border-green-400 text-white text-xs font-semibold mr-2 px-4 py-2 rounded-md cursor-pointer hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 inline-block"
-                                            (click)="createUserAttribute()">Create</label>
-                                    </div>
+                            </div>
 
-                                    <label for="new-attribute-modal"
-                                        class="bg-white text-gray-700 text-xs font-semibold mr-4 px-4 py-2 rounded-md border border-gray-300 cursor-pointer hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 inline-block">Close</label>
+                            <div class="modal-action">
+                                <div
+                                    [ngClass]="attributeName == '' || attributeType == '' || duplicateNameExists? 'cursor-not-allowed' : ''">
+                                    <label
+                                        [ngClass]="attributeName == '' || attributeType == '' || duplicateNameExists ? 'opacity-50 cursor-not-allowed pointer-events-none':'cursor-pointer opacity-100'"
+                                        class="bg-green-100 text-green-700 border border-green-400 text-white text-xs font-semibold mr-2 px-4 py-2 rounded-md cursor-pointer hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 inline-block"
+                                        (click)="createUserAttribute()">Add attribute</label>
                                 </div>
+
+                                <label for="new-attribute-modal"
+                                    class="bg-white text-gray-700 text-xs font-semibold mr-4 px-4 py-2 rounded-md border border-gray-300 cursor-pointer hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 inline-block">Close</label>
                             </div>
                         </div>
                     </div>
+
+
                     <div class="tooltip tooltip-bottom" data-tip="Upload more records to the project">
                         <button [routerLink]="['../add']"
                             class="mr-1 inline-flex items-center px-2.5 py-2 border border-gray-300 shadow-sm text-xs font-semibold rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none cursor-pointer">

--- a/src/app/projects/components/project-settings/project-settings.component.html
+++ b/src/app/projects/components/project-settings/project-settings.component.html
@@ -70,16 +70,7 @@
                                             {{attributeContainer.get("name").value}}
                                         </td>
                                         <td class="whitespace-nowrap text-center px-3 py-2 text-sm text-gray-500">
-                                            <div class="tooltip tooltip-right"
-                                                [attr.data-tip]="attributeContainer.get('state').value == 'USABLE' || attributeContainer.get('state').value == 'RUNNING' ? 'Cannot edit data type' : 'Edit your data type'">
-                                                    <kern-dropdown [dropdownOptions]="{
-                                                        optionArray: dataTypesArray,
-                                                        buttonCaption: attributeContainer.get('dataTypeName').value,
-                                                        valuePropertyPath: 'value',
-                                                        isDisabled: attributeContainer.get('state').value == 'USABLE' || attributeContainer.get('state').value == 'RUNNING'
-                                                    }" (optionClicked)="updateDataType($event,attributeContainer.get('id').value)">
-                                                    </kern-dropdown>
-                                            </div>
+                                            {{attributeContainer.get('dataTypeName').value}}
                                         </td>
                                         <td class="whitespace-nowrap text-center px-3 py-2 text-sm text-gray-500">
                                             <label class="cursor-pointer">
@@ -116,7 +107,7 @@
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-2 mt-1 align-top">
                 <div class="items-center flex flex-row">
                     <div class="tooltip tooltip-bottom" data-tip="Add new attribute">
-                        <button (click)="createUserAttribute()"
+                        <label for="new-attribute-modal"
                             class="mr-1 inline-flex items-center px-2.5 py-1.5 border border-gray-300 shadow-sm text-xs font-semibold rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none cursor-pointer">
                             <svg xmlns="http://www.w3.org/2000/svg" class="mr-1 h-5 w-5 inline-block stroke-current"
                                 fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -124,7 +115,46 @@
                                     d="M12 4v16m8-8H4" />
                             </svg>
                             Add new attibute
-                        </button>
+                        </label>
+
+                        <input type="checkbox" id="new-attribute-modal" class="modal-toggle">
+
+                        <div class="modal">
+                            <div class="modal-box text-black bg-white justify-center" style="overflow: initial;">
+                                <h1 class="text-lg text-gray-900 mb-2 text-center mb-4">Add new attribute
+                                </h1>
+
+                                <div class="grid grid-cols-2 gap-2 items-center"
+                                    style="grid-template-columns: max-content auto;">
+
+                                    <span data-tip="Enter an attribute name"
+                                        class="cursor-help tooltip tooltip-right card-title mb-0 label-text"><span
+                                            class="underline"
+                                            style="text-decoration-style: dotted;text-underline-offset: 2px;text-decoration-color: #22c55e">Attribute
+                                            name</span></span>
+                                    <input [(ngModel)]="attributeName" placeholder="Enter an attribute name..."
+                                        class="input input-sm input-bordered placeholder-italic" />
+
+                                    <span data-tip="Select an attribute type"
+                                        class="cursor-help tooltip tooltip-right card-title mb-0 label-text"><span
+                                            class="underline"
+                                            style="text-decoration-style: dotted;text-underline-offset: 2px;text-decoration-color: #22c55e">Attribute
+                                            type</span></span>
+                                    <kern-dropdown [dropdownOptions]="{
+                                        optionArray: dataTypesArray,
+                                        buttonCaption: attributeType
+                                    }" (optionClicked)="updateDataType($event)"></kern-dropdown>
+                                </div>
+                                <div class="modal-action text-center mt-4">
+                                    <label for="new-attribute-modal"
+                                        [ngClass]="attributeName == '' || attributeType == '' ? 'cursor-not-allowed opacity-50':'cursor-pointer opacity-100'"
+                                        class="bg-green-100 text-green-700 border border-green-400 text-white text-xs font-semibold mr-2 px-4 py-2 rounded-md cursor-pointer hover:bg-green-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 inline-block"
+                                        (click)="createUserAttribute()">Create</label>
+                                    <label for="new-attribute-modal"
+                                        class="bg-white text-gray-700 text-xs font-semibold mr-4 px-4 py-2 rounded-md border border-gray-300 cursor-pointer hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 inline-block">Close</label>
+                                </div>
+                            </div>
+                        </div>
                     </div>
                     <div class="tooltip tooltip-bottom" data-tip="Upload more records to the project">
                         <button [routerLink]="['../add']"

--- a/src/app/projects/components/project-settings/project-settings.component.html
+++ b/src/app/projects/components/project-settings/project-settings.component.html
@@ -70,13 +70,16 @@
                                             {{attributeContainer.get("name").value}}
                                         </td>
                                         <td class="whitespace-nowrap text-center px-3 py-2 text-sm text-gray-500">
-                                            <select formControlName="dataType"
-                                                class="select select-sm select-bordered pr-8 max-w-xs">
-                                                <option *ngFor="let type of dataTypesArray" [value]="type.value">
-                                                    {{type.name
-                                                    }}
-                                                </option>
-                                            </select>
+                                            <div class="tooltip tooltip-right"
+                                                [attr.data-tip]="attributeContainer.get('state').value == 'USABLE' || attributeContainer.get('state').value == 'RUNNING' ? 'Cannot edit data type' : 'Edit your data type'">
+                                                    <kern-dropdown [dropdownOptions]="{
+                                                        optionArray: dataTypesArray,
+                                                        buttonCaption: attributeContainer.get('dataTypeName').value,
+                                                        valuePropertyPath: 'value',
+                                                        isDisabled: attributeContainer.get('state').value == 'USABLE' || attributeContainer.get('state').value == 'RUNNING'
+                                                    }" (optionClicked)="updateDataType($event,attributeContainer.get('id').value)">
+                                                    </kern-dropdown>
+                                            </div>
                                         </td>
                                         <td class="whitespace-nowrap text-center px-3 py-2 text-sm text-gray-500">
                                             <label class="cursor-pointer">

--- a/src/app/projects/components/project-settings/project-settings.component.html
+++ b/src/app/projects/components/project-settings/project-settings.component.html
@@ -107,7 +107,7 @@
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-2 mt-1 align-top">
                 <div class="items-center flex flex-row">
                     <div class="tooltip tooltip-bottom" data-tip="Add new attribute">
-                        <label for="new-attribute-modal"
+                        <label (click)="openModalAttribute()"
                             class="mr-1 inline-flex items-center px-2.5 py-1.5 border border-gray-300 shadow-sm text-xs font-semibold rounded-md text-gray-700 bg-white hover:bg-gray-50 focus:outline-none cursor-pointer">
                             <svg xmlns="http://www.w3.org/2000/svg" class="mr-1 h-5 w-5 inline-block stroke-current"
                                 fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -142,14 +142,14 @@
                                     Attribute name exists
                                 </div>
 
-                                <div class="grid grid-cols-2 gap-2 items-center"
+                                <div class="grid grid-cols-2 gap-2 items-center mt-3"
                                     style="grid-template-columns: max-content auto;">
                                     <span data-tip="Select an attribute type"
                                         class="cursor-help tooltip tooltip-right card-title mb-0 label-text"><span
                                             class="underline"
                                             style="text-decoration-style: dotted;text-underline-offset: 2px;text-decoration-color: #22c55e">Attribute
                                             type</span></span>
-                                    <kern-dropdown [dropdownOptions]="{
+                                    <kern-dropdown class="ml-1.5" [dropdownOptions]="{
                                         optionArray: dataTypesArray,
                                         buttonCaption: attributeType
                                     }" (optionClicked)="updateDataType($event)"></kern-dropdown>

--- a/src/app/projects/components/project-settings/project-settings.component.ts
+++ b/src/app/projects/components/project-settings/project-settings.component.ts
@@ -15,6 +15,7 @@ import { ConfigManager } from 'src/app/base/services/config-service';
 import { UserManager } from 'src/app/util/user-manager';
 import { CommentDataManager, CommentType } from 'src/app/base/components/comment/comment-helper';
 import { dataTypes } from 'src/app/util/data-types';
+import { toPythonFunctionName } from 'src/app/util/helper-functions';
 
 @Component({
   selector: 'kern-project-settings',
@@ -1054,6 +1055,7 @@ export class ProjectSettingsComponent implements OnInit, OnDestroy, AfterViewIni
     this.attributeType = dataType;
   }
   changeAttributeName(event: any) {
+    this.attributeName = toPythonFunctionName(event.target.value);
     const findDuplicate = this.attributes.find(att => att.name == event.target.value);
     this.duplicateNameExists = findDuplicate != undefined ? true : false;
   }

--- a/src/app/projects/components/project-settings/project-settings.component.ts
+++ b/src/app/projects/components/project-settings/project-settings.component.ts
@@ -116,12 +116,14 @@ export class ProjectSettingsComponent implements OnInit, OnDestroy, AfterViewIni
   }
   labelMap: Map<string, []> = new Map<string, []>();
   @ViewChild('modalInput', { read: ElementRef }) myModalnewRecordTask: ElementRef;
+  @ViewChild('newAttributeModal', { read: ElementRef }) newAttributeModal: ElementRef;
   downloadedModelsList$: any;
   downloadedModelsQuery$: any;
   downloadedModels: any[];
   isManaged: boolean = true;
   attributeName: string = '';
   attributeType: string = 'Text';
+  duplicateNameExists: boolean = false;
 
   constructor(
     private routeService: RouteService,
@@ -1030,10 +1032,14 @@ export class ProjectSettingsComponent implements OnInit, OnDestroy, AfterViewIni
 
   createUserAttribute() {
     const attributeType = this.dataTypesArray.find((type) => type.name === this.attributeType).value;
+
+    if (this.duplicateNameExists) return;
+
     this.projectApolloService
       .createUserAttribute(this.project.id, this.attributeName, attributeType)
       .pipe(first())
       .subscribe((res) => {
+        this.newAttributeModal.nativeElement.checked = true;
         const id = res?.data?.createUserAttribute.attributeId;
         if (id) {
           localStorage.setItem("isNewAttribute", "true");
@@ -1046,5 +1052,9 @@ export class ProjectSettingsComponent implements OnInit, OnDestroy, AfterViewIni
   }
   updateDataType(dataType: string) {
     this.attributeType = dataType;
+  }
+  changeAttributeName(event: any) {
+    const findDuplicate = this.attributes.find(att => att.name == event.target.value);
+    this.duplicateNameExists = findDuplicate != undefined ? true : false;
   }
 }

--- a/src/app/projects/components/project-settings/project-settings.component.ts
+++ b/src/app/projects/components/project-settings/project-settings.component.ts
@@ -1057,4 +1057,24 @@ export class ProjectSettingsComponent implements OnInit, OnDestroy, AfterViewIni
     const findDuplicate = this.attributes.find(att => att.name == event.target.value);
     this.duplicateNameExists = findDuplicate != undefined ? true : false;
   }
+
+  openModalAttribute() {
+    this.newAttributeModal.nativeElement.checked = true;
+    this.attributeName = this.findFreeAttributeName();
+  }
+
+  findFreeAttributeName(): string {
+    const regEx = "^attribute_([0-9]+)$"
+    let counterList = [];
+    for (const item of this.attributes) {
+      const match = item.name.match(regEx);
+      if (match) counterList.push(parseInt(match[1]));
+    }
+    if (counterList.length > 0) {
+      const max = Math.max(...counterList) + 1;
+      return "attribute_" + max;
+    } else {
+      return "attribute_" + (this.attributes.length + 1);
+    }
+  }
 }

--- a/src/app/projects/components/project-settings/project-settings.component.ts
+++ b/src/app/projects/components/project-settings/project-settings.component.ts
@@ -1070,11 +1070,6 @@ export class ProjectSettingsComponent implements OnInit, OnDestroy, AfterViewIni
       const match = item.name.match(regEx);
       if (match) counterList.push(parseInt(match[1]));
     }
-    if (counterList.length > 0) {
-      const max = Math.max(...counterList) + 1;
-      return "attribute_" + max;
-    } else {
-      return "attribute_" + (this.attributes.length + 1);
-    }
+    return "attribute_" + (counterList.length > 0 ? (Math.max(...counterList) + 1) : (this.attributes.length + 1));
   }
 }

--- a/src/app/projects/components/project-settings/project-settings.component.ts
+++ b/src/app/projects/components/project-settings/project-settings.component.ts
@@ -14,6 +14,7 @@ import { WeakSourceApolloService } from 'src/app/base/services/weak-source/weak-
 import { ConfigManager } from 'src/app/base/services/config-service';
 import { UserManager } from 'src/app/util/user-manager';
 import { CommentDataManager, CommentType } from 'src/app/base/components/comment/comment-helper';
+import { dataTypes } from 'src/app/util/data-types';
 
 @Component({
   selector: 'kern-project-settings',
@@ -33,14 +34,8 @@ export class ProjectSettingsComponent implements OnInit, OnDestroy, AfterViewIni
     return LabelingTask;
   }
 
-  dataTypesArray = [
-    { name: 'Category', value: 'CATEGORY' },
-    { name: 'Text', value: 'TEXT' },
-    { name: 'Integer', value: 'INTEGER' },
-    { name: 'Float', value: 'FLOAT' },
-    { name: 'Boolean', value: 'BOOLEAN' },
-    { name: 'Unknown', value: 'UNKNOWN' },
-  ];
+  dataTypesArray = dataTypes;
+  
   granularityTypesArray = [
     { name: 'Attribute', value: 'ON_ATTRIBUTE' },
     { name: 'Token', value: 'ON_TOKEN' }

--- a/src/app/projects/components/project-settings/project-settings.component.ts
+++ b/src/app/projects/components/project-settings/project-settings.component.ts
@@ -35,7 +35,7 @@ export class ProjectSettingsComponent implements OnInit, OnDestroy, AfterViewIni
   }
 
   dataTypesArray = dataTypes;
-  
+
   granularityTypesArray = [
     { name: 'Attribute', value: 'ON_ATTRIBUTE' },
     { name: 'Token', value: 'ON_TOKEN' }
@@ -120,6 +120,8 @@ export class ProjectSettingsComponent implements OnInit, OnDestroy, AfterViewIni
   downloadedModelsQuery$: any;
   downloadedModels: any[];
   isManaged: boolean = true;
+  attributeName: string = '';
+  attributeType: string = 'Text';
 
   constructor(
     private routeService: RouteService,
@@ -315,7 +317,7 @@ export class ProjectSettingsComponent implements OnInit, OnDestroy, AfterViewIni
           dataTypeName: this.dataTypesArray.find((type) => type.value === att?.dataType).name
         });
 
-        if (att.state == 'INITIAL') {
+        if (att.state == 'INITIAL' || att.state == 'FAILED') {
           group.get('isPrimaryKey').disable();
         }
         group.valueChanges.pipe(distinctUntilChanged()).subscribe(() => {
@@ -1027,8 +1029,9 @@ export class ProjectSettingsComponent implements OnInit, OnDestroy, AfterViewIni
   }
 
   createUserAttribute() {
+    const attributeType = this.dataTypesArray.find((type) => type.name === this.attributeType).value;
     this.projectApolloService
-      .createUserAttribute(this.project.id)
+      .createUserAttribute(this.project.id, this.attributeName, attributeType)
       .pipe(first())
       .subscribe((res) => {
         const id = res?.data?.createUserAttribute.attributeId;
@@ -1041,10 +1044,7 @@ export class ProjectSettingsComponent implements OnInit, OnDestroy, AfterViewIni
         }
       });
   }
-
-  updateDataType(dataType: string, attributeId: string) {
-    this.projectApolloService.updateAttribute(this.project.id, attributeId, dataType)
-      .pipe(first())
-      .subscribe();
+  updateDataType(dataType: string) {
+    this.attributeType = dataType;
   }
 }

--- a/src/app/projects/components/project-settings/project-settings.component.ts
+++ b/src/app/projects/components/project-settings/project-settings.component.ts
@@ -311,8 +311,10 @@ export class ProjectSettingsComponent implements OnInit, OnDestroy, AfterViewIni
           isPrimaryKey: att.isPrimaryKey,
           userCreated: att.userCreated,
           sourceCode: att.sourceCode,
-          state: att.state
+          state: att.state,
+          dataTypeName: this.dataTypesArray.find((type) => type.value === att?.dataType).name
         });
+
         if (att.state == 'INITIAL') {
           group.get('isPrimaryKey').disable();
         }
@@ -1038,5 +1040,11 @@ export class ProjectSettingsComponent implements OnInit, OnDestroy, AfterViewIni
             });
         }
       });
+  }
+
+  updateDataType(dataType: string, attributeId: string) {
+    this.projectApolloService.updateAttribute(this.project.id, attributeId, dataType)
+      .pipe(first())
+      .subscribe();
   }
 }

--- a/src/app/util/data-types.ts
+++ b/src/app/util/data-types.ts
@@ -1,0 +1,8 @@
+export const dataTypes = [
+    { name: 'Category', value: 'CATEGORY' },
+    { name: 'Text', value: 'TEXT' },
+    { name: 'Integer', value: 'INTEGER' },
+    { name: 'Float', value: 'FLOAT' },
+    { name: 'Boolean', value: 'BOOLEAN' },
+    { name: 'Unknown', value: 'UNKNOWN' },
+  ];

--- a/src/app/util/data-types.ts
+++ b/src/app/util/data-types.ts
@@ -1,8 +1,7 @@
 export const dataTypes = [
-    { name: 'Category', value: 'CATEGORY' },
-    { name: 'Text', value: 'TEXT' },
-    { name: 'Integer', value: 'INTEGER' },
-    { name: 'Float', value: 'FLOAT' },
-    { name: 'Boolean', value: 'BOOLEAN' },
-    { name: 'Unknown', value: 'UNKNOWN' },
-  ];
+  { name: 'Category', value: 'CATEGORY' },
+  { name: 'Text', value: 'TEXT' },
+  { name: 'Integer', value: 'INTEGER' },
+  { name: 'Float', value: 'FLOAT' },
+  { name: 'Boolean', value: 'BOOLEAN' },
+];

--- a/src/app/util/helper-functions.ts
+++ b/src/app/util/helper-functions.ts
@@ -74,3 +74,7 @@ export function parseLogData(logs: string[], isType: InformationSourceType = nul
         );
     });
 }
+
+export function toPythonFunctionName(str: string) {
+    return str.replace(/\s+/g, '_').replace(/[^\w]/gi, '').trim();
+}

--- a/src/app/util/helper-functions.ts
+++ b/src/app/util/helper-functions.ts
@@ -86,3 +86,14 @@ export function getUserAvatarUri(user) {
     }
     return "assets/avatars/" + avatarId + ".png";
 }
+
+export function getColorForDataType(dataType): string {
+    switch (dataType) {
+        case 'CATEGORY': return 'amber';
+        case 'TEXT': return 'lime';
+        case 'BOOLEAN': return 'cyan';
+        case 'INTEGER': return 'indigo';
+        case 'FLOAT': return 'purple';
+        default: return 'gray';
+    }
+}

--- a/src/app/weak-supervision/components/weak-source-details/weak-source-details.component.html
+++ b/src/app/weak-supervision/components/weak-source-details/weak-source-details.component.html
@@ -74,9 +74,9 @@
                 <div class="flex flex-row items-center">
                     <div class="text-sm leading-5 font-medium text-gray-700 inline-block mr-2">Attributes</div>
                     <span *ngFor="let attribute of attributes" (click)="copyToClipboard(attribute.name)"
-                        data-tip="Click to copy" class="tooltip">
-                        <div
-                            class="cursor-pointer border items-center px-2 py-0.5 rounded text-xs font-medium text-center m-2 bg-gray-100 text-gray-700 border-gray-400 hover:bg-gray-200">
+                        [attr.data-tip]="attribute.dataTypeName + ' - Click to copy' " class="tooltip">
+                        <div [ngClass]="'bg-'+attribute.color+'-100 text-'+attribute.color+'-700 border border-'+attribute.color+'-400 hover:bg-'+attribute.color+'-200'"
+                            class="cursor-pointer border items-center px-2 py-0.5 rounded text-xs font-medium text-center m-2">
                             {{attribute.name}}
                         </div>
                     </span>

--- a/src/app/weak-supervision/components/weak-source-details/weak-source-details.component.ts
+++ b/src/app/weak-supervision/components/weak-source-details/weak-source-details.component.ts
@@ -21,7 +21,7 @@ import {
 import { combineLatest, forkJoin, Subscription, timer } from 'rxjs';
 import { InformationSourceType, informationSourceTypeToString, LabelingTask, LabelSource } from 'src/app/base/enum/graphql-enums';
 import { InformationSourceCodeLookup, InformationSourceExamples } from '../information-sources-code-lookup';
-import { dateAsUTCDate } from 'src/app/util/helper-functions';
+import { dateAsUTCDate, toPythonFunctionName } from 'src/app/util/helper-functions';
 import { NotificationService } from 'src/app/base/services/notification.service';
 import { OrganizationApolloService } from 'src/app/base/services/organization/organization-apollo.service';
 import { schemeCategory24 } from 'src/app/util/colors';
@@ -528,7 +528,7 @@ export class WeakSourceDetailsComponent
 
   changeInformationSourceName(event) {
     // if (this.informationSource.informationSourceType != InformationSourceType.LABELING_FUNCTION) return;
-    this.informationSourceName = this.toPythonFunctionName(event.target.value);
+    this.informationSourceName = toPythonFunctionName(event.target.value);
     if (this.informationSourceName != event.target.value) {
       event.target.value = this.informationSourceName;
     }
@@ -586,12 +586,6 @@ export class WeakSourceDetailsComponent
     return /class ([\w]+)\([^)]+\):/.exec(codeToCheck);
   }
 
-  toPythonFunctionName(str: string) {
-    //spaces will be _ everything else will be removed
-
-    return str.replace(/\s+/g, '_').replace(/[^\w]/gi, '').trim();
-  }
-
   getInformationSourceTypeString(type: InformationSourceType) {
     return informationSourceTypeToString(type, false, true);
   }
@@ -641,17 +635,18 @@ export class WeakSourceDetailsComponent
           const label = record.calculatedLabels.length > 0 ? record.calculatedLabels[1] : '-';
           record.calculatedLabelsResult = {
             label: {
-            label: label,
-            color: this.getColorForLabel(label),
-            count: 1,
-            displayAmount: false
-          }};
+              label: label,
+              color: this.getColorForLabel(label),
+              count: 1,
+              displayAmount: false
+            }
+          };
         } else {
           const resultDict = {};
-          if(record.calculatedLabels.length > 0) {
+          if (record.calculatedLabels.length > 0) {
             record.calculatedLabels.forEach(e => {
               const label = this.getLabelFromExtractionResult(e);
-              if (!resultDict[label])  {
+              if (!resultDict[label]) {
                 resultDict[label] = {
                   label: label,
                   color: this.getColorForLabel(label),
@@ -659,9 +654,9 @@ export class WeakSourceDetailsComponent
                 };
               }
               resultDict[label].count++;
-            });          
+            });
             const displayAmount = Object.keys(resultDict).length > 1;
-            for (const key in resultDict) { 
+            for (const key in resultDict) {
               resultDict[key].displayAmount = displayAmount || resultDict[key].count > 1;
             }
           } else {

--- a/src/app/weak-supervision/components/weak-source-details/weak-source-details.component.ts
+++ b/src/app/weak-supervision/components/weak-source-details/weak-source-details.component.ts
@@ -21,13 +21,14 @@ import {
 import { combineLatest, forkJoin, Subscription, timer } from 'rxjs';
 import { InformationSourceType, informationSourceTypeToString, LabelingTask, LabelSource } from 'src/app/base/enum/graphql-enums';
 import { InformationSourceCodeLookup, InformationSourceExamples } from '../information-sources-code-lookup';
-import { dateAsUTCDate, toPythonFunctionName } from 'src/app/util/helper-functions';
+import { dateAsUTCDate, getColorForDataType, toPythonFunctionName } from 'src/app/util/helper-functions';
 import { NotificationService } from 'src/app/base/services/notification.service';
 import { OrganizationApolloService } from 'src/app/base/services/organization/organization-apollo.service';
 import { schemeCategory24 } from 'src/app/util/colors';
 import { UserManager } from 'src/app/util/user-manager';
 import { RecordApolloService } from 'src/app/base/services/record/record-apollo.service';
 import { CommentDataManager, CommentType } from 'src/app/base/components/comment/comment-helper';
+import { dataTypes } from 'src/app/util/data-types';
 
 @Component({
   selector: 'kern-weak-source-details',
@@ -90,6 +91,7 @@ export class WeakSourceDetailsComponent
   currentRecordIdx: number = -1;
   sampleRecords: any;
   selectedAttribute: string = '';
+  dataTypesArray = dataTypes;
 
   constructor(
     private router: Router,
@@ -616,6 +618,10 @@ export class WeakSourceDetailsComponent
     this.subscriptions$.push(attributes$.subscribe((attributes) => {
       attributes.sort((a, b) => a.relativePosition - b.relativePosition);
       this.attributes = attributes;
+      this.attributes.forEach(attribute => {
+        attribute.color = getColorForDataType(attribute.dataType);
+        attribute.dataTypeName = this.dataTypesArray.find((type) => type.value === attribute.dataType).name;
+      });
     }));
     return attributes$.pipe(first());
   }

--- a/src/app/weak-supervision/components/weak-supervision/weak-supervision.component.ts
+++ b/src/app/weak-supervision/components/weak-supervision/weak-supervision.component.ts
@@ -10,7 +10,7 @@ import { NotificationService } from 'src/app/base/services/notification.service'
 import { ProjectApolloService } from 'src/app/base/services/project/project-apollo.service';
 import { RouteService } from 'src/app/base/services/route.service';
 import { WeakSourceApolloService } from 'src/app/base/services/weak-source/weak-source-apollo.service';
-import { dateAsUTCDate } from 'src/app/util/helper-functions';
+import { dateAsUTCDate, toPythonFunctionName } from 'src/app/util/helper-functions';
 import { UserManager } from 'src/app/util/user-manager';
 import { InformationSourceCodeLookup, InformationSourceExamples } from '../information-sources-code-lookup';
 
@@ -528,14 +528,10 @@ export class WeakSupervisionComponent implements OnInit, OnDestroy {
   }
 
   changeInformationSourceName(event) {
-    this.functionName = this.toPythonFunctionName(event.target.value);
+    this.functionName = toPythonFunctionName(event.target.value);
     if (this.functionName != event.target.value) {
       event.target.value = this.functionName;
     }
-  }
-
-  toPythonFunctionName(str: string) {
-    return str.replace(/\s+/g, '_').replace(/[^\w]/gi, '').trim();
   }
 
   prepareSelectionList() {


### PR DESCRIPTION
implements:
- https://github.com/code-kern-ai/refinery/issues/142

works with:
- https://github.com/code-kern-ai/refinery-gateway/pull/68
- https://github.com/code-kern-ai/refinery-ac-exec-env/pull/6
- https://github.com/code-kern-ai/refinery-ui/pull/75
- https://github.com/code-kern-ai/refinery-tokenizer/pull/11
- https://github.com/code-kern-ai/refinery-submodule-model/pull/21

## Frontend
Tasks:
- Add a new kern-dropdown with all data types on the attribute-calculation page
- Set conditions when it should be enabled/disabled
- Change datatype on project-settings (remove dropdown and add it as a text)
- Implement modal for adding a new attribute with name and data type
- Update queries and mutation according to the new modal
- Visual and UI improvements (small issues to keep the consistency)
- Testing and review 
Estimation time FE: 9h