### PR TITLE
Close modal without saving the data slice and visual improvements on data-browser

### DIFF
--- a/src/app/base/components/bricks-integrator/bricks-integrator.component.scss
+++ b/src/app/base/components/bricks-integrator/bricks-integrator.component.scss
@@ -1,7 +1,3 @@
-.tooltip::before {
-    z-index: 50;
-}
-
 .editor-pre {
     line-height: 21px;
     font-family: monospace;

--- a/src/app/base/components/comment/comment.component.scss
+++ b/src/app/base/components/comment/comment.component.scss
@@ -1,7 +1,3 @@
-.tooltip::before {
-    z-index: 50;
-}
-
 .width-icon-menues {
     width: 128px;
 }

--- a/src/app/base/components/dropdown/dropdown.component.scss
+++ b/src/app/base/components/dropdown/dropdown.component.scss
@@ -1,7 +1,3 @@
-.tooltip::before {
-    z-index: 50;
-}
-
 .width-icon-menues {
     width: 128px;
 }

--- a/src/app/base/components/export/export.component.scss
+++ b/src/app/base/components/export/export.component.scss
@@ -15,3 +15,7 @@
     resize: none;
     overflow: auto;
 }
+
+.tooltip::before {
+    z-index: 50;
+}

--- a/src/app/base/components/export/export.component.scss
+++ b/src/app/base/components/export/export.component.scss
@@ -15,7 +15,3 @@
     resize: none;
     overflow: auto;
 }
-
-.tooltip::before {
-    z-index: 50;
-}

--- a/src/app/base/components/heuristic-statuses/heuristic-statuses.component.scss
+++ b/src/app/base/components/heuristic-statuses/heuristic-statuses.component.scss
@@ -1,3 +1,0 @@
-.tooltip::before {
-    z-index: 50;
-}

--- a/src/app/data/components/data-browser/data-browser.component.html
+++ b/src/app/data/components/data-browser/data-browser.component.html
@@ -22,16 +22,6 @@
             <div *ngIf="isSearchMenuOpen || isSearchMenuVisible" class="transition_all opacity-0"
                 [ngClass]="isSearchMenuVisible&&isSearchMenuOpen?'opacity-100':null">
                 <!-- Also, you can choose a preset below -->
-                <div class="flex justify-center items-center w-full relative text-gray-400" style="top:6px"
-                    data-tip="Outdated slice&#10;save to update"
-                    [ngClass]="activeSlice?.sliceType == SliceTypes.STATIC_OUTLIER || !(displayOutdatedWarning  || (activeSlice?.static && staticDataSliceCurrentCount!=null && activeSlice.count!=staticDataSliceCurrentCount)) ? 'hidden':'tooltip'">
-                    <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24"
-                        stroke="currentColor" stroke-width="2">
-                        <path stroke-linecap="round" stroke-linejoin="round"
-                            d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
-                    </svg>
-                </div>
-
                 <div class="mt-2" [ngClass]="this.sliceNames.size > 6 ? null : 'hidden'">
                     <input type="text" placeholder="enter name to filter" [(ngModel)]="dataSliceFilter"
                         (ngModelChange)="filterAvailableSlices()" class="w-full input input-sm input-bordered p-2">
@@ -84,10 +74,21 @@
 
                 <div class="relative">
                     <div class="absolute inset-0 flex items-center">
-                        <div class="w-full border-t border-gray-300"></div>
+                        <div class="w-full border-t border-gray-300"
+                            [ngClass]="activeSlice?.sliceType == SliceTypes.STATIC_OUTLIER || !(displayOutdatedWarning  || (activeSlice?.static && staticDataSliceCurrentCount!=null && activeSlice.count!=staticDataSliceCurrentCount)) ? '' : 'ml-20'">
+                        </div>
                     </div>
                     <div class="relative flex justify-start">
-                        <span class="pr-3 bg-white text-lg font-medium text-gray-900">Filter</span>
+                        <span class="pr-2 bg-white text-lg font-medium text-gray-900">Filter</span>
+                        <div class="flex items-center tooltip-right text-gray-400"
+                            data-tip="Outdated slice&#10;save to update"
+                            [ngClass]="activeSlice?.sliceType == SliceTypes.STATIC_OUTLIER || !(displayOutdatedWarning  || (activeSlice?.static && staticDataSliceCurrentCount!=null && activeSlice.count!=staticDataSliceCurrentCount)) ? 'hidden':'tooltip'">
+                            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24"
+                                stroke="currentColor" stroke-width="2">
+                                <path stroke-linecap="round" stroke-linejoin="round"
+                                    d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+                            </svg>
+                        </div>
                     </div>
                 </div>
                 <span class="text-sm text-gray-400">You can filter and order all your data in the browser

--- a/src/app/data/components/data-browser/data-browser.component.html
+++ b/src/app/data/components/data-browser/data-browser.component.html
@@ -6,7 +6,8 @@
             [ngClass]="isSearchMenuVisible? 'search_menu_width':null">
             <div class="flex flex-row items-center">
                 <ng-template [ngIf]="isSearchMenuOpen">
-                    <div class="pr-3 bg-white text-lg font-medium text-gray-900">Existing data slices</div>
+                    <div class="bg-white text-lg font-medium text-gray-900" style="padding-right: 14px;">Existing data
+                        slices</div>
                 </ng-template>
                 <div #menuOpener class="cursor-pointer" (click)="openSearchMenu(menuOpener)">
                     <svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-layout-sidebar"
@@ -21,7 +22,7 @@
             <div *ngIf="isSearchMenuOpen || isSearchMenuVisible" class="transition_all opacity-0"
                 [ngClass]="isSearchMenuVisible&&isSearchMenuOpen?'opacity-100':null">
                 <!-- Also, you can choose a preset below -->
-                <div class="flex justify-center items-center w-full h-full relative -mt-2 ml-2" style="top:6px"
+                <div class="flex justify-center items-center w-full relative text-gray-400" style="top:6px"
                     data-tip="Outdated slice&#10;save to update"
                     [ngClass]="activeSlice?.sliceType == SliceTypes.STATIC_OUTLIER || !(displayOutdatedWarning  || (activeSlice?.static && staticDataSliceCurrentCount!=null && activeSlice.count!=staticDataSliceCurrentCount)) ? 'hidden':'tooltip'">
                     <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="none" viewBox="0 0 24 24"

--- a/src/app/data/components/data-browser/data-browser.component.html
+++ b/src/app/data/components/data-browser/data-browser.component.html
@@ -944,9 +944,10 @@
 
 <kern-modal [isOpen]="dataBrowserModals.filter.open" closeButton="X" [modalBoxStyle]="{'width':'35rem'}" [acceptButton]="{
     buttonCaption: dataBrowserModals.filter.sliceNameExists? 'Update data slice':'Save data slice',
-    disabled: inputSliceName.value == ''
-}"
-    (optionClicked)="dataBrowserModals.filter.open = false; dataBrowserModals.filter.sliceNameExists? updateSliceByName(inputSliceName.value) :createSlice(inputSliceName.value);inputSliceName.value=''">
+    disabled: inputSliceName.value == '',
+    emitObject: this,
+    emitFunction: dataBrowserModals.filter.sliceNameExists? updateSliceByName :createSlice
+}" (optionClicked)="dataBrowserModals.filter.open = false;">
     <div class="flex flex-grow justify-center text-lg leading-6 text-gray-900 font-medium">
         Data slice creation</div>
     <div class="mb-2 flex flex-grow justify-center text-sm">
@@ -996,8 +997,9 @@
         <div class="flex w-full justify-between mt-2">
             <input #inputSliceName type="text" class="w-full input input-bordered input-sm" placeholder="Enter name"
                 name="dataSliceName" [value]="dataBrowserModals.filter.name"
-                (keyup)="checkNameExists(inputSliceName.value)" (keydown.enter)="dataBrowserModals.filter.open = false; dataBrowserModals.filter.sliceNameExists ?
-            updateSliceByName(inputSliceName.value):createSlice(inputSliceName.value)">
+                (input)="setSliceName(inputSliceName.value)" (keyup)="checkNameExists(inputSliceName.value)"
+                (keydown.enter)="dataBrowserModals.filter.open = false; dataBrowserModals.filter.sliceNameExists ?
+            updateSliceByName():createSlice()">
         </div>
     </div>
 

--- a/src/app/data/components/data-browser/data-browser.component.scss
+++ b/src/app/data/components/data-browser/data-browser.component.scss
@@ -86,9 +86,6 @@ input[type="number"] {
   overflow-wrap: anywhere;
 }
 
-.tooltip::before {
-  z-index: 50;
-}
 
 .tooltip_slice_max_width::before {
   max-width: 200px;

--- a/src/app/data/components/data-browser/data-browser.component.scss
+++ b/src/app/data/components/data-browser/data-browser.component.scss
@@ -86,7 +86,6 @@ input[type="number"] {
   overflow-wrap: anywhere;
 }
 
-
 .tooltip_slice_max_width::before {
   max-width: 200px;
 }

--- a/src/app/data/components/data-browser/data-browser.component.ts
+++ b/src/app/data/components/data-browser/data-browser.component.ts
@@ -1380,11 +1380,11 @@ export class DataBrowserComponent implements OnInit, OnDestroy {
     }
   }
 
-  createSlice(name: string) {
-    if (!name) return;
+  createSlice() {
+    if (!this.dataBrowserModals.filter.name) return;
 
     this.projectApolloService.createDataSlice(this.projectId,
-      name,
+      this.dataBrowserModals.filter.name,
       this.isStaticDataSlice,
       this.getRawFilterForSave(),
       this.filterParser.parseFilterToExtended())
@@ -1406,8 +1406,7 @@ export class DataBrowserComponent implements OnInit, OnDestroy {
   }
 
 
-  updateSliceByName(name: string) {
-    this.dataBrowserModals.filter.name = name;
+  updateSliceByName() {
     for (let value of this.slicesById.values()) {
       if (value.name == this.dataBrowserModals.filter.name) {
         this.activeSlice = value;
@@ -2134,5 +2133,9 @@ export class DataBrowserComponent implements OnInit, OnDestroy {
     groupItem.get('lower').setValue(0);
     groupItem.get('upper').setValue(100);
     groupItem.get('active').setValue(false);
+  }
+
+  setSliceName(sliceName: string) {
+    this.dataBrowserModals.filter.name = sliceName;
   }
 }

--- a/src/app/knowledge-bases/components/knowledge-bases.component.scss
+++ b/src/app/knowledge-bases/components/knowledge-bases.component.scss
@@ -1,11 +1,7 @@
-.tooltip::before {
-    z-index: 50;
-}
-
 .line-clamp {
     display: -webkit-box;
     -webkit-line-clamp: 2;
-    -webkit-box-orient: vertical;  
+    -webkit-box-orient: vertical;
     overflow: hidden;
 }
 

--- a/src/app/knowledge-bases/knowledge-base-details/knowledge-base-details/knowledge-base-details.component.scss
+++ b/src/app/knowledge-bases/knowledge-base-details/knowledge-base-details/knowledge-base-details.component.scss
@@ -1,7 +1,3 @@
 .tooltip-margin::before {
     margin-left: 70px;
 }
-
-.tooltip::before {
-    z-index: 50;
-}

--- a/src/app/labeling-suite/main-component/labeling-suite.component.scss
+++ b/src/app/labeling-suite/main-component/labeling-suite.component.scss
@@ -4,7 +4,6 @@
 }
 
 .tooltip::before {
-  z-index: 50;
   max-width: 250px;
 }
 

--- a/src/app/labeling-suite/sub-components/labeling/labeling.component.scss
+++ b/src/app/labeling-suite/sub-components/labeling/labeling.component.scss
@@ -1,5 +1,4 @@
 .tooltip::before {
-  z-index: 50;
   max-width: 230px;
 }
 

--- a/src/app/labeling-suite/sub-components/overview-table/overview-table.component.scss
+++ b/src/app/labeling-suite/sub-components/overview-table/overview-table.component.scss
@@ -1,7 +1,3 @@
-.tooltip::before {
-  z-index: 50;
-}
-
 .w-icon {
   max-width: 1.5rem;
 }

--- a/src/app/labeling-suite/sub-components/task-header/task-header.component.scss
+++ b/src/app/labeling-suite/sub-components/task-header/task-header.component.scss
@@ -1,5 +1,4 @@
 .tooltip::before {
-  z-index: 50;
   max-width: 230px;
 }
 

--- a/src/app/model-callbacks/components/model-callbacks.component.scss
+++ b/src/app/model-callbacks/components/model-callbacks.component.scss
@@ -1,7 +1,3 @@
-.tooltip::before {
-    z-index: 50;
-}
-
 .margin-svg {
     margin-top: -26px;
 }

--- a/src/app/projects/components/project-settings/components/embeddings/embeddings.component.scss
+++ b/src/app/projects/components/project-settings/components/embeddings/embeddings.component.scss
@@ -1,3 +1,0 @@
-.tooltip::before {
-    z-index: 50;
-}

--- a/src/app/projects/components/project-settings/components/embeddings/embeddings.component.ts
+++ b/src/app/projects/components/project-settings/components/embeddings/embeddings.component.ts
@@ -19,6 +19,7 @@ export class EmbeddingsComponent implements OnInit, OnDestroy, OnChanges {
 
   @Input() project: Project;
   @Input() useableTextAttributes: Attribute[];
+  @Input() useableAttributes: Attribute[];
   @Input() settingModals: SettingModals;
   @Input() isManaged: boolean;
   @Input() embeddings: Embedding[];
@@ -158,7 +159,7 @@ export class EmbeddingsComponent implements OnInit, OnDestroy, OnChanges {
   }
 
   private checkStillLoading() {
-    this.somethingLoading = this.useableTextAttributes == undefined || this.useableTextAttributes?.length == 0 || this.embeddingHandles == undefined || this.downloadedModels?.length == 0;
+    this.somethingLoading = this.useableAttributes == undefined || this.useableAttributes?.length == 0 || this.embeddingHandles == undefined || this.downloadedModels?.length == 0;
   }
 
   handleWebsocketNotification(msgParts) {

--- a/src/app/projects/components/project-settings/project-settings.component.html
+++ b/src/app/projects/components/project-settings/project-settings.component.html
@@ -82,8 +82,9 @@
     </div>
 
     <kern-embeddings [embeddingHandles]="embeddingHandles" [useableTextAttributes]="useableTextAttributes"
-        [embeddings]="embeddings" [settingModals]="settingModals" [project]="project" [isManaged]="isManaged"
-        [dataHandlerHelper]="dataHandlerHelper" [attributes]="attributes"></kern-embeddings>
+        [useableAttributes]="useableAttributes" [embeddings]="embeddings" [settingModals]="settingModals"
+        [project]="project" [isManaged]="isManaged" [dataHandlerHelper]="dataHandlerHelper" [attributes]="attributes">
+    </kern-embeddings>
 
     <kern-labeling-tasks [settingModals]="settingModals" [project]="project" [dataHandlerHelper]="dataHandlerHelper"
         [useableAttributes]="useableAttributes" [attributes]="attributes" [lh]="lh">

--- a/src/app/projects/components/project-settings/project-settings.component.scss
+++ b/src/app/projects/components/project-settings/project-settings.component.scss
@@ -4,9 +4,6 @@
   overflow-x: auto;
 }
 
-.tooltip::before {
-  z-index: 50;
-}
 
 .capitalize-first {
   text-transform: lowercase;

--- a/src/app/record-ide/components/record-ide.component.scss
+++ b/src/app/record-ide/components/record-ide.component.scss
@@ -1,3 +1,0 @@
-.tooltip::before {
-    z-index: 50;
-}

--- a/src/app/weak-supervision/components/crowd-labeler-details/component/crowd-labeler-details.component.scss
+++ b/src/app/weak-supervision/components/crowd-labeler-details/component/crowd-labeler-details.component.scss
@@ -2,9 +2,6 @@
     max-height: calc(100vh - 230px);
 }
 
-.tooltip::before {
-    z-index: 50;
-}
 
 .text-left {
     text-align: left;

--- a/src/app/weak-supervision/components/weak-source-details/weak-source-details.component.scss
+++ b/src/app/weak-supervision/components/weak-source-details/weak-source-details.component.scss
@@ -1,7 +1,3 @@
-.tooltip::before {
-    z-index: 50;
-}
-
 .tooltip-text-smaller::before {
     margin-top: 10px;
     text-transform: none;

--- a/src/app/weak-supervision/components/weak-supervision/weak-supervision.component.scss
+++ b/src/app/weak-supervision/components/weak-supervision/weak-supervision.component.scss
@@ -1,7 +1,3 @@
-.tooltip::before {
-  z-index: 50;
-}
-
 .margin-svg {
   margin-top: -26px;
 }

--- a/src/app/zero-shot-details/component/zero-shot-details.component.scss
+++ b/src/app/zero-shot-details/component/zero-shot-details.component.scss
@@ -2,9 +2,6 @@
     max-height: calc(100vh - 230px);
 }
 
-.tooltip::before {
-    z-index: 50;
-}
 
 .text-left {
     text-align: left;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -46,3 +46,7 @@ body {
 .modal {
   align-items: center;
 }
+
+.tooltip::before {
+  z-index: 50;
+}


### PR DESCRIPTION
- Close modal on data browser does not save the data slice
- Visual improvements for icon for outdated slice
- Tooltip class removed from all files and added into the global styles
- Fix for loading icon on embeddings subsection when there are no text attributes